### PR TITLE
release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.0
+Added iOS Swift Package Manager support
 ## 0.1.0
 Initial release
 ## 0.2.0

--- a/ios/large_file_handler.podspec
+++ b/ios/large_file_handler.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'large_file_handler'
-  s.version          = '0.0.1'
+  s.version          = '0.4.0'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: large_file_handler
 description: "The Large File Handler Plugin designed to efficiently work with large files, for example allows you to download large files from network or copy files from the Flutter app's assets to the device's local file system. This is useful when you need to access large files at native part in your plugins"
-version: 0.3.1
+version: 0.4.0
 homepage: https://github.com/DenisovAV/large_file_handler
 repository: https://github.com/DenisovAV/large_file_handler
 


### PR DESCRIPTION
Bump version to 0.4.0 following iOS Swift Package Manager support (merged in #3).

- `pubspec.yaml`: 0.3.1 → 0.4.0
- `ios/large_file_handler.podspec`: 0.0.1 → 0.4.0
- `CHANGELOG.md`: added 0.4.0 entry