### PR TITLE
release 0.4.1: fix pub.dev score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.1
+Shortened package description and added dartdoc comments to the public API
 ## 0.4.0
 Added iOS Swift Package Manager support
 ## 0.1.0

--- a/ios/large_file_handler.podspec
+++ b/ios/large_file_handler.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'large_file_handler'
-  s.version          = '0.4.0'
+  s.version          = '0.4.1'
   s.summary          = 'A new Flutter plugin project.'
   s.description      = <<-DESC
 A new Flutter plugin project.

--- a/lib/large_file_handler.dart
+++ b/lib/large_file_handler.dart
@@ -1,21 +1,45 @@
 import 'dart:async';
 import 'large_file_handler_platform_interface.dart';
 
+/// Copies large files from Flutter assets or the network to the device's
+/// local file system, with optional progress tracking.
+///
+/// All `targetPath` values are resolved relative to the application's
+/// documents directory before being handed to the native implementation.
 class LargeFileHandler {
+  /// Copies the asset [assetName] (relative to the `assets/` directory) to
+  /// [targetPath] on the local file system.
+  ///
+  /// Completes when the copy finishes. Throws a `PlatformException` if the
+  /// asset cannot be found or the copy fails.
   Future<void> copyAssetToLocalStorage({required String assetName, required String targetPath}) =>
       LargeFileHandlerPlatform.instance.copyAssetToLocalStorage(assetName, targetPath);
 
+  /// Downloads the file at [assetUrl] to [targetPath] on the local file system.
+  ///
+  /// Completes when the download finishes. Throws a `PlatformException` if the
+  /// URL is invalid or the download fails.
   Future<void> copyNetworkAssetToLocalStorage({required String assetUrl, required String targetPath}) =>
       LargeFileHandlerPlatform.instance.copyUrlToLocalStorage(assetUrl, targetPath);
 
+  /// Copies the asset [assetName] to [targetPath], emitting copy progress.
+  ///
+  /// Returns a [Stream] of integers from 0 to 100 representing the percentage
+  /// completed. The stream closes once the copy is finished.
   Stream<int> copyAssetToLocalStorageWithProgress(
           {required String assetName, required String targetPath}) =>
       LargeFileHandlerPlatform.instance.copyAssetToLocalStorageWithProgress(assetName, targetPath);
 
+  /// Downloads the file at [assetUrl] to [targetPath], emitting download progress.
+  ///
+  /// Returns a [Stream] of integers from 0 to 100 representing the percentage
+  /// completed. The stream closes once the download is finished.
   Stream<int> copyNetworkAssetToLocalStorageWithProgress(
           {required String assetUrl, required String targetPath}) =>
       LargeFileHandlerPlatform.instance.copyUrlToLocalStorageWithProgress(assetUrl, targetPath);
 
+  /// Returns whether a file already exists at [targetPath] on the local
+  /// file system.
   Future<bool> fileExists({required String targetPath}) =>
       LargeFileHandlerPlatform.instance.fileExists(targetPath);
 }

--- a/lib/large_file_handler_platform_interface.dart
+++ b/lib/large_file_handler_platform_interface.dart
@@ -23,14 +23,20 @@ abstract class LargeFileHandlerPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// Downloads the file at [url] to [targetName] on the local file system.
   Future<void> copyUrlToLocalStorage(String url, String targetName);
 
+  /// Copies the asset [assetName] to [targetName] on the local file system.
   Future<void> copyAssetToLocalStorage(String assetName, String targetName);
 
+  /// Copies the asset [assetName] to [targetName], emitting copy progress
+  /// as integers from 0 to 100.
   Stream<int> copyAssetToLocalStorageWithProgress(String assetName, String targetName);
 
+  /// Downloads the file at [url] to [targetName], emitting download progress
+  /// as integers from 0 to 100.
   Stream<int> copyUrlToLocalStorageWithProgress(String url, String targetName);
 
+  /// Returns whether a file already exists at [targetPath].
   Future<bool> fileExists(String targetPath);
-
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: large_file_handler
-description: "The Large File Handler Plugin designed to efficiently work with large files, for example allows you to download large files from network or copy files from the Flutter app's assets to the device's local file system. This is useful when you need to access large files at native part in your plugins"
-version: 0.4.0
+description: "Efficiently copy large files from Flutter assets or download them from the network to the device's local file system, with optional progress tracking."
+version: 0.4.1
 homepage: https://github.com/DenisovAV/large_file_handler
 repository: https://github.com/DenisovAV/large_file_handler
 


### PR DESCRIPTION
Fixes the two pub.dev analysis penalties reported for 0.4.0.

**Pubspec (was 0/10):** description was ~290 chars; pub.dev requires 60–180. Shortened to a concise 158-char summary.

**Documentation (was 0/10):** only 14.8% of the public API had dartdoc comments (threshold is 20%). Added dartdoc to `LargeFileHandler` (class + all 5 methods) and the abstract methods on `LargeFileHandlerPlatform`.

Version bumped to 0.4.1 in `pubspec.yaml` and `ios/large_file_handler.podspec`; CHANGELOG updated. `dart doc` runs clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)