### PR TITLE
Exclude build/ from published package; expand 0.5.0 changelog

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -4,3 +4,4 @@ docs/
 .remember/
 CLAUDE.md
 test_reports/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.5.0
-Added macOS, Windows, and Linux support; web now throws UnsupportedError instead of failing to compile
+Added macOS, Windows, and Linux support; web now throws UnsupportedError instead of failing to compile. macOS now supports the Swift Package Manager, and the package is WASM-compatible.
 ## 0.4.1
 Shortened package description and added dartdoc comments to the public API
 ## 0.4.0


### PR DESCRIPTION
## Summary
Release hygiene for 0.5.x — found while running `flutter pub publish --dry-run`.

- **Package weight: 14 MB → 395 KB.** A stray `build/test_cache/...cache.dill.track.dill` (44 MB uncompressed) from `flutter test` was being pulled into the published archive. `build/` is gitignored but `pub publish` still included it, so it is now explicitly listed in `.pubignore`.
- **CHANGELOG:** the 0.5.0 entry now also notes macOS Swift Package Manager support and WASM compatibility (both real, score-affecting improvements that were missing from the note).

## Test Plan
- [x] `flutter pub publish --dry-run` — 0 warnings, archive now **395 KB** (was 14 MB)
- [x] No source/behavior changes — packaging + docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)